### PR TITLE
fix: copy hedera key and certificate

### DIFF
--- a/docker/ubi8-init-java21/stage_files.sh
+++ b/docker/ubi8-init-java21/stage_files.sh
@@ -26,4 +26,6 @@ for file in $files; do
 done
 
 # copy hedera.crt and hedera.key to /opt/hgcapp/services-hedera/HapiApp2.0/
-cp /shared-hapiapp/hedera.* /opt/hgcapp/services-hedera/HapiApp2.0/
+if [ -d /shared-hapiapp ]; then
+  cp /shared-hapiapp/hedera.* /opt/hgcapp/services-hedera/HapiApp2.0/
+fi


### PR DESCRIPTION
## Description

This pull request changes the following:

- During the test found out we also need to copy hedera.crt and hedera.key to HapiApp2.0 directory

### Related Issues

- Closes #44 
