### PR TITLE
feat: clone backup loader from infrastructure container

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -131,6 +131,14 @@ jobs:
           push: ${{ github.event.inputs.dry-run-enabled != 'true' }}
           tags: ghcr.io/${{ github.repository }}/kubectl-bats:${{ needs.prepare-release.outputs.version }}
 
+      - name: Build Docker Image (backup-uploader)
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: docker/backup-uploader
+          platforms: linux/amd64, linux/arm64
+          push: ${{ github.event.inputs.dry-run-enabled != 'true' }}
+          tags: ghcr.io/${{ github.repository }}/backup-uploader:${{ needs.prepare-release.outputs.version }}
+
   create-github-release:
     name: Github / Release
     runs-on: solo-linux-medium

--- a/docker/backup-uploader/Dockerfile
+++ b/docker/backup-uploader/Dockerfile
@@ -1,0 +1,27 @@
+FROM rclone/rclone:1.69.1 as rclone
+
+FROM ubuntu:18.04
+
+ARG UNAME=hedera
+ARG UID=2000
+ARG GID=2000
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash $UNAME
+
+COPY --from=rclone /usr/local/bin/rclone /bin/rclone
+
+RUN apt-get update && \
+  apt-get -y install \
+    cron \
+    ca-certificates \
+    jq
+
+COPY cron /etc/cron.d/backup
+ADD backup.sh /
+ADD entrypoint.sh /
+RUN chmod ugo+x /backup.sh /entrypoint.sh
+
+COPY rclone.conf /root/.config/rclone/rclone.conf
+COPY rclone.conf /home/hedera/.config/rclone/rclone.conf
+
+ENTRYPOINT ["bash", "-c", "./entrypoint.sh"]

--- a/docker/backup-uploader/backup.sh
+++ b/docker/backup-uploader/backup.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+readonly BACKUP_UPLOADER_BUCKET_1
+readonly BACKUP_UPLOADER_BUCKET_2
+
+function pretty_print() {
+    local date
+    local message
+    date=$(date '+%Y-%m-%d %H:%M:%S')
+    message=$(echo "$1" | jq -Rs .)
+    echo "{\"date\":\"$date\", \"message\":'$message'}"
+}
+
+function exit_with_failure() {
+    pretty_print "ERROR $1"
+    exit 1
+}
+
+if [ -z "${BACKUP_UPLOADER_BUCKET_1}" ]; then
+    exit_with_failure "BACKUP_UPLOADER_BUCKET_1 is not defined"
+fi
+
+saved_dir="/opt/hgcapp/services-hedera/HapiApp2.0/data/saved/com.hedera.services.ServicesMain"
+node_id=$(ls $saved_dir)
+
+if [ ! -d "$saved_dir/$node_id/123/" ]; then
+  exit_with_failure "SAVED STATE DIRECTORY DOES NOT EXIST"
+else
+   readonly node_id
+   readonly saved_dir
+fi
+
+cd "$saved_dir/$node_id/123/" || exit_with_failure "COULD NOT cd TO $saved_dir/$node_id/123/"
+mapfile -t all_states < <(ls)
+
+backup_hostname=$(cat /etc/hostname); readonly backup_hostname
+
+rclone_cmd="rclone --bwlimit 51200K --log-level INFO --use-json-log"; readonly rclone_cmd
+
+if [ -n "${BACKUP_UPLOADER_BUCKET_2}" ]; then
+  if [ "$node_id" = "0" ] || [ "$node_id" = "9" ]; then
+    bucket="${BACKUP_UPLOADER_BUCKET_1}"
+  else
+    bucket="${BACKUP_UPLOADER_BUCKET_2}"
+  fi
+else
+bucket="${BACKUP_UPLOADER_BUCKET_1}"
+fi
+readonly bucket
+
+# Take the next to last backup. We do not currently have a way
+# to ensure the backup has finished writing, so taking the second oldest
+# is the safest method we can currently use.
+second_to_last_state=${all_states[-2]}
+if [ -z "$second_to_last_state" ]; then
+  # This can happen if no states have been written
+  exit_with_failure "ERROR - No Second to Last State found! Nothing to back up. Found states: ${all_states[*]}"
+else
+  readonly second_to_last_state
+fi
+
+backup_latest="$bucket/nodes/$backup_hostname/latest"; readonly backup_latest
+backup_destination="$bucket/$backup_hostname/$second_to_last_state"
+
+# add in VERSION file for humans so we know what this state is about
+
+pretty_print "ATTEMPTING SYNC $second_to_last_state TO $backup_latest"
+
+# shellcheck disable=SC2086
+if $rclone_cmd sync $second_to_last_state backups:$backup_latest; then
+    pretty_print "SUCCESSFULLY SYNCED TO $backup_latest"
+else
+    exit_with_failure "ERROR SYNCING TO $backup_latest"
+fi
+
+# copy in version file
+# shellcheck disable=SC2086
+version_source=/opt/hgcapp/services-hedera/HapiApp2.0/VERSION; readonly version_source
+version_dest=$backup_latest/; readonly version_dest
+
+pretty_print "ATTEMPTING COPY $version_source TO $version_dest"
+if $rclone_cmd copy $version_source backups:$version_dest; then
+    pretty_print "COPY SUCCESSFUL $version_dest"
+else
+    exit_with_failure "ERROR DURING COPY TO $version_dest"
+fi
+
+pretty_print "BACKING UP TO $backup_destination"
+# shellcheck disable=SC2086
+if $rclone_cmd sync backups:$backup_latest backups:$backup_destination; then
+    pretty_print "BACKUP SUCCESSFUL $backup_destination"
+else
+    exit_with_failure "ERROR BACKING UP TO $backup_destination"
+fi
+
+current_round_number="/$backup_hostname.txt"
+echo $second_to_last_state > $current_round_number
+$rclone_cmd copy $current_round_number backups:$bucket/current_round/
+pretty_print "LATEST ROUND ${second_to_last_state} WRITTEN TO $bucket/current_round/$current_round_number"
+
+# only backup stats file on the midnight backup
+if [ "$(date +%H)" = "00" ] && [ "$(date +%H%M%S)" -lt "001000" ]; then
+  stats_bucket="${BACKUP_UPLOADER_BUCKET_1}"; readonly stats_bucket
+  # shellcheck disable=SC2046,SC2086
+  rclone copy /opt/hgcapp/services-hedera/HapiApp2.0/data/stats/MainNetStats${node_id}.csv backups:$stats_bucket/stats/$backup_hostname/MainNetStats${node_id}-$(date --iso-8601).csv
+  pretty_print "SUCCESSFULLY BACKED STATS CSV FILE"
+fi

--- a/docker/backup-uploader/build.gradle.kts
+++ b/docker/backup-uploader/build.gradle.kts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("com.palantir.docker") version "0.35.0"
+}
+
+val repo = "ghcr.io"
+val registry = "hashgraph/full-stack-testing"
+val containerName = "backup-uploader"
+val appVersion = project.version.toString()
+
+docker {
+    name = "${repo}/${registry}/${containerName}:${appVersion}"
+    version = appVersion
+    files("entrypoint.sh")
+    buildx(true)
+    if (!System.getenv("CI").isNullOrEmpty()) {
+        platform("linux/arm64", "linux/amd64")
+        push(true)
+    } else {
+        load(true) // loads the image into the local docker daemon, doesn't support multi-platform
+    }
+}

--- a/docker/backup-uploader/cron
+++ b/docker/backup-uploader/cron
@@ -1,0 +1,3 @@
+# backup
+*/10 * * * * root /backup.sh
+# backup

--- a/docker/backup-uploader/entrypoint.sh
+++ b/docker/backup-uploader/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') INITIALIZING BACKUP CONTAINER"
+while :
+do
+    # Source the main script here so that it runs in the current shell. Two
+    # important reasons:
+    #
+    # 1. all environment variables are passed in
+    # 2. ensure multiple copies can't be running (as there is no copy)
+    ( . ./backup.sh)
+    sleep 300
+done

--- a/docker/backup-uploader/image.txt
+++ b/docker/backup-uploader/image.txt
@@ -1,0 +1,1 @@
+gcr.io/hedera-registry/hedera-backups

--- a/docker/backup-uploader/rclone.conf
+++ b/docker/backup-uploader/rclone.conf
@@ -1,0 +1,5 @@
+[backups]
+type = google cloud storage
+location = us-west2
+bucket_policy_only = true
+service_account_file = /sa.json


### PR DESCRIPTION
## Description

This pull request changes the following:

- Clone uploader docker from infrastructure repo
- Did some experiment and find out old rclone 1.57 has compatibility issue when using access key to write to GCS.
- newer version rclone 1.69.1 does not have issue

### Related Issues

[Solo](https://github.com/hashgraph/solo/issues/1521)

