### PR TITLE
feat: fix issue with m4 chips when running java21

### DIFF
--- a/docker/ubi8-init-java21/entrypoint.sh
+++ b/docker/ubi8-init-java21/entrypoint.sh
@@ -30,7 +30,10 @@ if [[ -z "${JAVA_OPTS}" ]]; then
 fi
 
 # Fix for M4 chips
-JAVA_OPTS="${JAVA_OPTS} -XX:UseSVE=0"
+ARCH="$(uname -p)"
+if [[ "${ARCH}" == "amd64" || "${ARCH}" == "aarch64" ]]; then
+  JAVA_OPTS="${JAVA_OPTS} -XX:UseSVE=0"
+fi
 
 # Setup Heap Options
 JAVA_HEAP_OPTS=""


### PR DESCRIPTION
## Description

The following error occurs on MacOS X Sequoia on a M4 chipset when attempting to start a Solo deployment:

```
*********************************** ERROR *****************************************
Error in setting up nodes: failed to extract platform code in this pod 'solo-e2e-c1/network-node1-0' while using the 'kind-solo-e2e-c1' context: /home/hedera/extract-platform.sh: line 45:    87 Aborted                 jar xvf "${BUILD_ZIP_FILE}"
        88 Done                    | tee -a ${LOG_FILE}
:execContainer[network-node1-0,2d3cea5c-65d3-4e86-9400-23f39174dac2]: Failure occurred
***********************************************************************************
*********************************** ERROR *****************************************
node setup failed: Error in setting up nodes: failed to extract platform code in this pod 'solo-e2e-c1/network-node1-0' while using the 'kind-solo-e2e-c1' context: /home/hedera/extract-platform.sh: line 45:    87 Aborted                 jar xvf "${BUILD_ZIP_FILE}"
        88 Done                    | tee -a ${LOG_FILE}
:execContainer[network-node1-0,2d3cea5c-65d3-4e86-9400-23f39174dac2]: Failure occurred
***********************************************************************************
```

This PR applies the fix mentioned [here](https://github.com/corretto/corretto-21/issues/85#issuecomment-2537664384)

### Related Issues

- Closes #
