### PR TITLE
fix: add UseSVE java option on correct processor types

### DIFF
--- a/docker/ubi8-init-java21/entrypoint.sh
+++ b/docker/ubi8-init-java21/entrypoint.sh
@@ -31,7 +31,7 @@ fi
 
 # Fix for M4 chips
 ARCH="$(uname -p)"
-if [[ "${ARCH}" == "amd64" || "${ARCH}" == "aarch64" ]]; then
+if [[ "${ARCH}" == "arm64" || "${ARCH}" == "aarch64" ]]; then
   JAVA_OPTS="${JAVA_OPTS} -XX:UseSVE=0"
 fi
 


### PR DESCRIPTION
## Description

This PR changes the condition in which `UseSVE=0` is applied to the java options