### PR TITLE
fix: simplify zip and unzip installation in Dockerfile

### DIFF
--- a/docker/ubi8-init-java21/Dockerfile
+++ b/docker/ubi8-init-java21/Dockerfile
@@ -46,7 +46,7 @@ RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
     dnf clean all
 
 # Install zip and unzip
-RUN dnf -y install zip-3.0-23.el8 unzip-6.0-47.el8_10 && \
+RUN dnf -y install zip unzip && \
     dnf clean all
 
 # Install Java 21 Adoptium JDK


### PR DESCRIPTION
## Description

This pull request changes the following:

This pull request includes a small change to the `docker/ubi8-init-java21/Dockerfile`. The change simplifies the installation command for `zip` and `unzip` by removing version-specific references.

### Related Issues

- Closes #
