### PR TITLE
chore(ci): update commit analyzer to use conventionalcommits preset

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,11 @@
 {
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
     [
       "@semantic-release/release-notes-generator",
       {


### PR DESCRIPTION
**Description**:

Update the releaserc file commit analyzer plugin to use the conventional commits preset.

**Related Issue(s)**:

Fixes #91 
