### PR TITLE
fix: update max_map_count to resolve Consensus Node error with versions > v0.68.0-rc1

### DIFF
--- a/docker/ubi8-init-java21/Dockerfile
+++ b/docker/ubi8-init-java21/Dockerfile
@@ -127,6 +127,8 @@ RUN mkdir -p /etc/network-node/startup && \
     chown -R 2000:2000 /etc/network-node/config
 ADD stage_files.sh /etc/network-node/startup
 RUN chmod -R +x /etc/network-node/startup/stage_files.sh
+# Update to address error in Consensus Node with > v0.68.0-rc1
+RUN echo 220000 > /proc/sys/vm/max_map_count
 
 # Expose TCP/UDP Port Definitions
 EXPOSE 50111/tcp 50211/tcp 50212/tcp


### PR DESCRIPTION

## Description

This pull request changes the following:

- update max_map_count to resolve Consensus Node error with versions > v0.68.0-rc1

### Related Issues

- Relates to https://github.com/hiero-ledger/solo/issues/2875
