### PR TITLE
fix: update base image to dtzar/helm-kubectl and adjust package installation to fix kubectl-bats docker build issue

### DIFF
--- a/docker/kubectl-bats/Dockerfile
+++ b/docker/kubectl-bats/Dockerfile
@@ -14,22 +14,20 @@
 # limitations under the License.
 #
 
-FROM bitnami/kubectl:latest
+FROM dtzar/helm-kubectl:latest
 
 ENV BATS_HOME=/bats
 
-# switch to user root for setup
+# switch to root
 USER root
 
-# setup bats
-RUN apt-get update && \
-    apt-get install -y curl git vim python3 python3-pip jq && \
+RUN apk update && \
+    apk add --no-cache curl git vim python3 py3-pip jq bash && \
     git clone https://github.com/bats-core/bats-core.git "${BATS_HOME}"/bats-core && \
     git clone https://github.com/bats-core/bats-support.git "${BATS_HOME}"/test_helper/bats-support && \
     git clone https://github.com/bats-core/bats-assert.git "${BATS_HOME}"/test_helper/bats-assert && \
-    curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash && \
     curl -L https://github.com/mikefarah/yq/releases/download/v4.34.2/yq_linux_amd64 -o /usr/bin/yq && \
     chmod +x /usr/bin/yq
 
-#switch back to user 1001
+# switch back to non-root user (if image has a non-root user)
 USER 1001


### PR DESCRIPTION
## Description

This pull request updates the `docker/kubectl-bats/Dockerfile` to improve compatibility and streamline the setup process. The main focus is on switching to a new base image, updating package installation commands, and cleaning up unnecessary steps.

**Base image and package installation updates:**

* Changed the base image from `bitnami/kubectl:latest` to `dtzar/helm-kubectl:latest`, which includes both `kubectl` and `helm` for broader Kubernetes tooling support.
* Replaced `apt-get` commands with `apk` commands to match the new Alpine-based image, and updated package names accordingly (e.g., `py3-pip` instead of `python3-pip`).

**Setup simplification and cleanup:**

* Removed the manual installation of `helm` via script since the new base image already includes Helm.
* Added installation of `bash` for compatibility with BATS and related scripts.
* Clarified comments about switching user context, and maintained switching back to a non-root user at the end of setup.

### Related Issues

- Closes https://github.com/hashgraph/solo-containers/issues/77
