### PR TITLE
chore(ci): update GITHUB_TOKEN to GH_ACCESS_TOKEN in workflow

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Calculate Next Version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_USER_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_USER_NAME }}


### PR DESCRIPTION
**Description**:

Fix the name of a secret passed in from `GITHUB_TOKEN` to `GH_ACCESS_TOKEN`.

**Related Issue(s)**:

Fixes #100
