### PR TITLE
ci: Enable GPG signing for git tags

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -185,7 +185,7 @@ jobs:
           git_config_global: true
           git_user_signingkey: true
           git_commit_gpgsign: true
-          git_tag_gpgsign: false
+          git_tag_gpgsign: true
 
       - name: Setup Node
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0


### PR DESCRIPTION
## Description

This pull request changes the following:

- Enable GPG signing for git tags

### Related Issues

- Closes #
