### PR TITLE
ci: update GIT_EDITOR setting to prevent workflow hang during release

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -207,6 +207,6 @@ jobs:
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_USER_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
-          GIT_EDITOR: "true"  # Set to a non-interactive value to prevent errors
+          GIT_EDITOR: "echo 'Created-by: swirlds-automation' > $1"  # prevent opening an editor and causing the action to hang
         if: ${{ github.event.inputs.dry-run-enabled != 'true' && !cancelled() && !failure() }}
         run: npx semantic-release


### PR DESCRIPTION
## Description

This pull request changes the following:

- update GIT_EDITOR setting to prevent workflow hang during release

### Related Issues

- Closes #
