### PR TITLE
ci: update publish command to use non-signing git tag and change GitHub token secret

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -201,7 +201,7 @@ jobs:
 
       - name: Publish Semantic Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SOLO_GH_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_USER_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_USER_NAME }}

--- a/.releaserc
+++ b/.releaserc
@@ -17,7 +17,7 @@
       {
         "verifyReleaseCmd": "echo ${nextRelease.version} > VERSION",
         "prepareCmd": "echo ${nextRelease.version} > VERSION",
-        "publishCmd": "git tag ${nextRelease.version} && git push origin ${nextRelease.version}"
+        "publishCmd": "git tag --no-sign ${nextRelease.version} && git push origin ${nextRelease.version}"
       }
     ],
     "@semantic-release/git",


### PR DESCRIPTION
## Description

This pull request changes the following:

- ci: update publish command to use non-signing git tag and change GitHub token secret

### Related Issues

- Closes #
