### PR TITLE
ci: add GH_TOKEN environment variable for publishing

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -201,6 +201,7 @@ jobs:
 
       - name: Publish Semantic Release
         env:
+          GH_TOKEN: ${{ secrets.SOLO_GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.SOLO_GH_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_USER_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}


### PR DESCRIPTION
## Description

This pull request changes the following:

- ci: add GH_TOKEN environment variable for publishing

### Related Issues

- Closes #
