### PR TITLE
ci: update checkout action to disable credential persistence and use SOLO_GH_TOKEN

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -165,6 +165,8 @@ jobs:
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.SOLO_GH_TOKEN }}
 
       - name: Install GnuPG Tools
         run: |


### PR DESCRIPTION
## Description

This pull request changes the following:

- ci: update checkout action to disable credential persistence and use SOLO_GH_TOKEN

### Related Issues

- Closes #
