### PR TITLE
fix: update token references to use GH_ACCESS_TOKEN instead of SOLO_GH_TOKEN

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -166,7 +166,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          token: ${{ secrets.SOLO_GH_TOKEN }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Install GnuPG Tools
         run: |
@@ -203,8 +203,8 @@ jobs:
 
       - name: Publish Semantic Release
         env:
-          GH_TOKEN: ${{ secrets.SOLO_GH_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.SOLO_GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_USER_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_USER_NAME }}


### PR DESCRIPTION
## Description

This pull request changes the following:

- fix: update token references to use GH_ACCESS_TOKEN instead of SOLO_GH_TOKEN

### Related Issues

- Closes #
