### PR TITLE
feat: add explicit autostart commands for network-node

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -45,6 +45,7 @@ jobs:
     runs-on: solo-linux-medium
     outputs:
       version: ${{ steps.tag.outputs.version }}
+      should-release: ${{ steps.tag.outputs.should-release }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
@@ -79,14 +80,32 @@ jobs:
       - name: Extract Version
         id: tag
         run: |
-          [[ "${{ github.event.inputs.dry-run-enabled }}" == true && ! -f VERSION ]] && echo -n "0.0.0-latest" > VERSION
-          echo "version=$(cat VERSION | tr -d '[:space:]')" >> ${GITHUB_OUTPUT}
+          if [[ "${{ github.event.inputs.dry-run-enabled }}" == true && ! -f VERSION ]]; then
+            echo -n "0.0.0-latest" > VERSION
+          fi
+
+          if [[ -f VERSION ]]; then
+            version="$(tr -d '[:space:]' < VERSION)"
+          else
+            version=""
+          fi
+
+          if [[ -n "${version}" ]]; then
+            echo "version=${version}" >> "${GITHUB_OUTPUT}"
+            echo "should-release=true" >> "${GITHUB_OUTPUT}"
+            echo "Semantic release version resolved: ${version}"
+          else
+            echo "version=" >> "${GITHUB_OUTPUT}"
+            echo "should-release=false" >> "${GITHUB_OUTPUT}"
+            echo "No release version produced (likely no releasable commits). Skipping publish jobs."
+          fi
 
   publish-docker-image:
     name: Publish / Docker Image
     runs-on: solo-linux-medium
     needs:
       - prepare-release
+    if: ${{ needs.prepare-release.outputs.should-release == 'true' }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
@@ -169,7 +188,9 @@ jobs:
     name: Github / Release
     runs-on: solo-linux-medium
     needs:
+      - prepare-release
       - publish-docker-image
+    if: ${{ needs.prepare-release.outputs.should-release == 'true' }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1

--- a/docker/ubi8-s6-java25/rootfs/command/network-node-lifecycle
+++ b/docker/ubi8-s6-java25/rootfs/command/network-node-lifecycle
@@ -3,6 +3,8 @@ set -euo pipefail
 
 SERVICE_NAME="network-node"
 SERVICE_DIR="/run/service/${SERVICE_NAME}"
+HEDERA_HAPI_PATH="${HEDERA_HAPI_PATH:-/opt/hgcapp/services-hedera/HapiApp2.0}"
+AUTOSTART_FLAG_PATH="${HEDERA_HAPI_PATH}/state/network-node.enabled"
 MAX_ATTEMPTS="${NETWORK_NODE_LIFECYCLE_MAX_ATTEMPTS:-30}"
 SLEEP_SECONDS="${NETWORK_NODE_LIFECYCLE_SLEEP_SECONDS:-1}"
 MAIN_CLASS_PATTERN='[c]om.hedera.node.app.ServicesMain'
@@ -120,8 +122,17 @@ stop_service() {
   force_stop_services_main
 }
 
+enable_autostart() {
+  mkdir -p "$(dirname "${AUTOSTART_FLAG_PATH}")"
+  touch "${AUTOSTART_FLAG_PATH}"
+}
+
+disable_autostart() {
+  rm -f "${AUTOSTART_FLAG_PATH}"
+}
+
 usage() {
-  log "usage: $0 <start|stop|restart|status>"
+  log "usage: $0 <start|stop|restart|status|enable-autostart|disable-autostart|start-and-enable-autostart|stop-and-disable-autostart>"
 }
 
 action="${1:-}"
@@ -139,6 +150,20 @@ case "${action}" in
   status)
     shift
     exec /etc/s6-overlay/scripts/network-node-status "$@"
+    ;;
+  enable-autostart)
+    enable_autostart
+    ;;
+  disable-autostart)
+    disable_autostart
+    ;;
+  start-and-enable-autostart)
+    enable_autostart
+    start_service
+    ;;
+  stop-and-disable-autostart)
+    disable_autostart
+    stop_service
     ;;
   *)
     usage


### PR DESCRIPTION
## Summary
- add explicit `enable-autostart` and `disable-autostart` actions to `/command/network-node-lifecycle`
- add composite actions `start-and-enable-autostart` and `stop-and-disable-autostart`
- keep autostart marker handling co-located with lifecycle service control in the container helper

## Why
- allows Solo to call a single lifecycle helper command instead of embedding marker-file shell logic
- reduces orchestration-side command complexity and centralizes behavior in solo-container

## Validation
- `bash -n docker/ubi8-s6-java25/rootfs/command/network-node-lifecycle`