### PR TITLE
chore: specify image version tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,15 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 15
+  - package-ecosystem: "docker"
+    directories:
+      - "docker/backup-uploader"
+      - "docker/kubectl-bats"
+      - "docker/ubi8-init-dind"
+      - "docker/ubi8-init-java21"
+      - "docker/ubi8-init-java25"
+      - "docker/ubi8-s6-java21"
+      - "docker/ubi8-s6-java25"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 15

--- a/docker/kubectl-bats/Dockerfile
+++ b/docker/kubectl-bats/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM dtzar/helm-kubectl:4.1.4
+FROM dtzar/helm-kubectl:4.1.4@sha256:5101d9fa750a240ba6714551f18b46427110c190dbecef47eb27465ff6c57b50
 
 ENV BATS_HOME=/bats
 

--- a/docker/kubectl-bats/Dockerfile
+++ b/docker/kubectl-bats/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM dtzar/helm-kubectl:latest
+FROM dtzar/helm-kubectl:4.1.4
 
 ENV BATS_HOME=/bats
 

--- a/docker/ubi8-init-dind/Dockerfile
+++ b/docker/ubi8-init-dind/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-init:8.10
+FROM registry.access.redhat.com/ubi8/ubi-init:8.10@sha256:a777391b2ba1f6d51bd69c6284abdf59bedf04e999138c3fe8c5abd083ac258c
 ENV COMPOSE_VERSION=2.19.0
 
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \

--- a/docker/ubi8-init-dind/Dockerfile
+++ b/docker/ubi8-init-dind/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-init:latest
+FROM registry.access.redhat.com/ubi8/ubi-init:8.10
 ENV COMPOSE_VERSION=2.19.0
 
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \

--- a/docker/ubi8-init-java21/Dockerfile
+++ b/docker/ubi8-init-java21/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-init:latest
+FROM registry.access.redhat.com/ubi8/ubi-init:8.10
 # Define Standard Environment Variables
 ENV LC_ALL=C.UTF-8
 

--- a/docker/ubi8-init-java21/Dockerfile
+++ b/docker/ubi8-init-java21/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-init:8.10
+FROM registry.access.redhat.com/ubi8/ubi-init:8.10@sha256:a777391b2ba1f6d51bd69c6284abdf59bedf04e999138c3fe8c5abd083ac258c
 # Define Standard Environment Variables
 ENV LC_ALL=C.UTF-8
 

--- a/docker/ubi8-init-java25/Dockerfile
+++ b/docker/ubi8-init-java25/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-init:latest
+FROM registry.access.redhat.com/ubi8/ubi-init:8.10
 # Define Standard Environment Variables
 ENV LC_ALL=C.UTF-8
 

--- a/docker/ubi8-init-java25/Dockerfile
+++ b/docker/ubi8-init-java25/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-init:8.10
+FROM registry.access.redhat.com/ubi8/ubi-init:8.10@sha256:a777391b2ba1f6d51bd69c6284abdf59bedf04e999138c3fe8c5abd083ac258c
 # Define Standard Environment Variables
 ENV LC_ALL=C.UTF-8
 

--- a/docker/ubi8-s6-java21/Dockerfile
+++ b/docker/ubi8-s6-java21/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-init:latest
+FROM registry.access.redhat.com/ubi8/ubi-init:8.10
 # Define Standard Environment Variables
 ENV LC_ALL=C.UTF-8
 

--- a/docker/ubi8-s6-java21/Dockerfile
+++ b/docker/ubi8-s6-java21/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-init:8.10
+FROM registry.access.redhat.com/ubi8/ubi-init:8.10@sha256:a777391b2ba1f6d51bd69c6284abdf59bedf04e999138c3fe8c5abd083ac258c
 # Define Standard Environment Variables
 ENV LC_ALL=C.UTF-8
 

--- a/docker/ubi8-s6-java25/Dockerfile
+++ b/docker/ubi8-s6-java25/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-init:latest
+FROM registry.access.redhat.com/ubi8/ubi-init:8.10
 # Define Standard Environment Variables
 ENV LC_ALL=C.UTF-8
 

--- a/docker/ubi8-s6-java25/Dockerfile
+++ b/docker/ubi8-s6-java25/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM registry.access.redhat.com/ubi8/ubi-init:8.10
+FROM registry.access.redhat.com/ubi8/ubi-init:8.10@sha256:a777391b2ba1f6d51bd69c6284abdf59bedf04e999138c3fe8c5abd083ac258c
 # Define Standard Environment Variables
 ENV LC_ALL=C.UTF-8
 


### PR DESCRIPTION
## Description

This pull request adds pinned version tags to all Dockerfiles and updates the `dependabot` configuration to update those versions automatically.

Used version tags instead of commit hashes to support multi-arch.

### Related Issues

- Closes #181 
- Closes https://github.com/hiero-ledger/solo/issues/4236
